### PR TITLE
refactor: methods to encode AssetType

### DIFF
--- a/src/workflows/deposits/depositERC721.go
+++ b/src/workflows/deposits/depositERC721.go
@@ -11,15 +11,16 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	. "github.com/ethereum/go-ethereum/core/types"
 	"immutable.com/imx-core-sdk-golang/api/client"
-	"immutable.com/imx-core-sdk-golang/api/client/encoding"
 	"immutable.com/imx-core-sdk-golang/api/client/users"
 	"immutable.com/imx-core-sdk-golang/api/models"
 	"immutable.com/imx-core-sdk-golang/signers"
 	"immutable.com/imx-core-sdk-golang/utils"
 	"immutable.com/imx-core-sdk-golang/utils/ethereum"
 	"immutable.com/imx-core-sdk-golang/workflows/types"
+	helpers "immutable.com/imx-core-sdk-golang/workflows/utils"
 )
 
+// Execute performs the deposit workflow on the ERC721Deposit.
 func (d *ERC721Deposit) Execute(ctx context.Context, ethClient *ethereum.Client, apis *client.ImmutableXAPI, l1signer signers.L1Signer) (*Transaction, error) {
 	if d.Type != types.ERC721Type {
 		return nil, errors.New("invalid token type")
@@ -51,26 +52,11 @@ func (d *ERC721Deposit) Execute(ctx context.Context, ethClient *ethereum.Client,
 	}
 
 	// Perform encoding on asset details to get an assetType (required for stark contract request)
-	encodeParams := encoding.NewEncodeAssetParamsWithContext(ctx)
-	encodeParams.SetAssetType("asset")
-	encodeParams.SetEncodeAssetRequest(&models.EncodeAssetRequest{
-		Token: &models.EncodeAssetRequestToken{
-			Data: &models.EncodeAssetTokenData{
-				TokenID:      d.TokenId,
-				TokenAddress: d.TokenAddress,
-			},
-			Type: string(d.Type),
-		},
-	})
-	encodedAsset, err := apis.Encoding.EncodeAsset(encodeParams)
+	assetType, err := helpers.GetEncodedAssetTypeForERC721(ctx, apis, d.TokenId, d.TokenAddress)
 	if err != nil {
-		return nil, fmt.Errorf("error when calling `Encoding.EncodeAsset`: %v", err)
+		return nil, err
 	}
 
-	assetType, ok := new(big.Int).SetString(*encodedAsset.GetPayload().AssetType, 10)
-	if !ok {
-		return nil, fmt.Errorf("error converting encoded asset type to bigint: %v\n", *encodedAsset.GetPayload().AssetType)
-	}
 	starkKey, err := utils.HexToInt(*signableDeposit.StarkKey)
 	if err != nil {
 		return nil, fmt.Errorf("error converting StarkKey to bigint: %v\n", signableDeposit.StarkKey)

--- a/src/workflows/deposits/depositEth.go
+++ b/src/workflows/deposits/depositEth.go
@@ -11,15 +11,16 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	. "github.com/ethereum/go-ethereum/core/types"
 	"immutable.com/imx-core-sdk-golang/api/client"
-	"immutable.com/imx-core-sdk-golang/api/client/encoding"
 	"immutable.com/imx-core-sdk-golang/api/client/users"
 	"immutable.com/imx-core-sdk-golang/api/models"
 	"immutable.com/imx-core-sdk-golang/signers"
 	"immutable.com/imx-core-sdk-golang/utils"
 	"immutable.com/imx-core-sdk-golang/utils/ethereum"
 	"immutable.com/imx-core-sdk-golang/workflows/types"
+	helpers "immutable.com/imx-core-sdk-golang/workflows/utils"
 )
 
+// Execute performs the deposit workflow on the ETHDeposit.
 func (d *ETHDeposit) Execute(ctx context.Context, ethClient *ethereum.Client, apis *client.ImmutableXAPI, l1signer signers.L1Signer) (*Transaction, error) {
 	if d.Type != types.ETHType {
 		return nil, errors.New("invalid token type")
@@ -35,22 +36,11 @@ func (d *ETHDeposit) Execute(ctx context.Context, ethClient *ethereum.Client, ap
 		return nil, err
 	}
 
-	encodeParams := encoding.NewEncodeAssetParamsWithContext(ctx)
-	encodeParams.SetAssetType("asset")
-	encodeParams.SetEncodeAssetRequest(&models.EncodeAssetRequest{
-		Token: &models.EncodeAssetRequestToken{
-			Type: string(d.Type),
-		},
-	})
-	encodedAsset, err := apis.Encoding.EncodeAsset(encodeParams)
+	assetType, err := helpers.GetEncodedAssetTypeForEth(ctx, apis)
 	if err != nil {
-		return nil, fmt.Errorf("error when calling `Encoding.EncodeAsset`: %v", err)
+		return nil, err
 	}
 
-	assetType, ok := new(big.Int).SetString(*encodedAsset.GetPayload().AssetType, 10)
-	if !ok {
-		return nil, fmt.Errorf("error converting encoded asset type to bigint: %v\n", *encodedAsset.GetPayload().AssetType)
-	}
 	starkKey, err := utils.HexToInt(*signableDeposit.StarkKey)
 	if err != nil {
 		return nil, fmt.Errorf("error converting StarkKey to bigint: %v\n", *signableDeposit.StarkKey)

--- a/src/workflows/utils/encodeAssetType.go
+++ b/src/workflows/utils/encodeAssetType.go
@@ -1,0 +1,101 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"immutable.com/imx-core-sdk-golang/api/client"
+	"immutable.com/imx-core-sdk-golang/api/client/encoding"
+	"immutable.com/imx-core-sdk-golang/api/models"
+	"immutable.com/imx-core-sdk-golang/workflows/types"
+	"math/big"
+)
+
+const (
+	defaultAssetType  = "asset"
+	mintabelAssetType = "mintable-asset"
+)
+
+// GetEncodedAssetTypeForEth returns encoded AssetType for ETH.
+func GetEncodedAssetTypeForEth(
+	ctx context.Context,
+	api *client.ImmutableXAPI,
+) (*big.Int, error) {
+	encodeAssetRequestToken := &models.EncodeAssetRequestToken{
+		Type: string(types.ETHType),
+	}
+	return GetEncodedAssetType(ctx, api, encodeAssetRequestToken, defaultAssetType)
+}
+
+// GetEncodedAssetTypeForERC20 returns encoded AssetType for ERC20 token.
+func GetEncodedAssetTypeForERC20(
+	ctx context.Context,
+	api *client.ImmutableXAPI,
+	tokenId, tokenAddress string,
+) (*big.Int, error) {
+	encodeAssetRequestToken := &models.EncodeAssetRequestToken{
+		Data: &models.EncodeAssetTokenData{
+			TokenAddress: tokenAddress,
+			TokenID:      tokenId,
+		},
+		Type: string(types.ERC20Type),
+	}
+	return GetEncodedAssetType(ctx, api, encodeAssetRequestToken, defaultAssetType)
+}
+
+// GetEncodedAssetTypeForERC721 returns encoded AssetType for ERC721 token.
+func GetEncodedAssetTypeForERC721(
+	ctx context.Context,
+	api *client.ImmutableXAPI,
+	tokenId, tokenAddress string,
+) (*big.Int, error) {
+	encodeAssetRequestToken := &models.EncodeAssetRequestToken{
+		Data: &models.EncodeAssetTokenData{
+			TokenAddress: tokenAddress,
+			TokenID:      tokenId,
+		},
+		Type: string(types.ERC721Type),
+	}
+	return GetEncodedAssetType(ctx, api, encodeAssetRequestToken, defaultAssetType)
+}
+
+// GetEncodedMintableAssetTypeForERC721 returns encoded MintableAssetType for ERC721 token.
+func GetEncodedMintableAssetTypeForERC721(
+	ctx context.Context,
+	api *client.ImmutableXAPI,
+	tokenId, tokenAddress, blueprint string,
+) (*big.Int, error) {
+	encodeAssetRequestToken := &models.EncodeAssetRequestToken{
+		Data: &models.EncodeAssetTokenData{
+			ID:           tokenId,
+			TokenAddress: tokenAddress,
+			Blueprint:    blueprint,
+		},
+		Type: string(types.ERC721Type),
+	}
+	return GetEncodedAssetType(ctx, api, encodeAssetRequestToken, mintabelAssetType)
+}
+
+// GetEncodedAssetType performs encoding on asset details to get an AssetType (required for stark contract request)
+func GetEncodedAssetType(
+	ctx context.Context,
+	api *client.ImmutableXAPI,
+	encodeAssetRequestToken *models.EncodeAssetRequestToken,
+	assetType string,
+) (*big.Int, error) {
+
+	encodeParams := encoding.NewEncodeAssetParamsWithContext(ctx)
+	encodeParams.SetAssetType(assetType)
+	encodeParams.SetEncodeAssetRequest(&models.EncodeAssetRequest{
+		Token: encodeAssetRequestToken,
+	})
+	encodedAsset, err := api.Encoding.EncodeAsset(encodeParams)
+	if err != nil {
+		return nil, fmt.Errorf("error when calling `Encoding.EncodeAsset`: %v", err)
+	}
+
+	encodedAssetType, ok := new(big.Int).SetString(*encodedAsset.GetPayload().AssetType, 10)
+	if !ok {
+		return nil, fmt.Errorf("error converting encoded asset type to bigint: %v\n", *encodedAsset.GetPayload().AssetType)
+	}
+	return encodedAssetType, nil
+}


### PR DESCRIPTION
GetEncodedAssetType methods will also be used in withdrawal workflows.