### PR TITLE
refactor(deposit): Execute method renamed to Deposit

### DIFF
--- a/examples/workflows/deposits/deposit.go
+++ b/examples/workflows/deposits/deposit.go
@@ -15,7 +15,7 @@ func Demo_DepositWorkflow(ctx context.Context, ethClient *ethereum.Client, apis 
 	log.Println("Running Demo_DepositWorkflow")
 
 	depositRequest := deposits.NewETHDeposit("0.03")
-	transaction, err := depositRequest.Execute(ctx, ethClient, apis, l1signer)
+	transaction, err := depositRequest.Deposit(ctx, ethClient, apis, l1signer)
 
 	/*
 		// Uncomment for ERC20
@@ -23,13 +23,13 @@ func Demo_DepositWorkflow(ctx context.Context, ethClient *ethereum.Client, apis 
 		tokenAddress := "Token address here"
 		symbol := "Token symbol"
 		depositERC20Request := deposits.NewERC20Deposit(amount, tokenAddress, symbol)
-		transaction, err := depositERC20Request.Execute(ctx, ethClient, apis, l1signer)
+		transaction, err := depositERC20Request.Deposit(ctx, ethClient, apis, l1signer)
 	*/
 
 	/*
 		// Uncomment for ERC721
 		depositERC721Request := deposits.NewERC721Deposit("7", "0x0fB969a08c7C39BA99c1628b59c0B7E5611BD396")
-		transaction, err := depositERC721Request.Execute(ctx, ethClient, apis, l1signer)
+		transaction, err := depositERC721Request.Deposit(ctx, ethClient, apis, l1signer)
 	*/
 
 	if err != nil {

--- a/src/workflows/deposits/depositERC20.go
+++ b/src/workflows/deposits/depositERC20.go
@@ -20,8 +20,8 @@ import (
 	helpers "immutable.com/imx-core-sdk-golang/workflows/utils"
 )
 
-// Execute performs the deposit workflow on the ERC20Deposit.
-func (d *ERC20Deposit) Execute(ctx context.Context, ethClient *ethereum.Client, api *client.ImmutableXAPI, l1signer signers.L1Signer) (*eth.Transaction, error) {
+// Deposit performs the deposit workflow on the ERC20Deposit.
+func (d *ERC20Deposit) Deposit(ctx context.Context, ethClient *ethereum.Client, api *client.ImmutableXAPI, l1signer signers.L1Signer) (*eth.Transaction, error) {
 	if d.Type != types.ERC20Type {
 		return nil, errors.New("invalid token type")
 	}

--- a/src/workflows/deposits/depositERC721.go
+++ b/src/workflows/deposits/depositERC721.go
@@ -18,8 +18,8 @@ import (
 	helpers "immutable.com/imx-core-sdk-golang/workflows/utils"
 )
 
-// Execute performs the deposit workflow on the ERC721Deposit.
-func (d *ERC721Deposit) Execute(ctx context.Context, ethClient *ethereum.Client, api *client.ImmutableXAPI, l1signer signers.L1Signer) (*eth.Transaction, error) {
+// Deposit performs the deposit workflow on the ERC721Deposit.
+func (d *ERC721Deposit) Deposit(ctx context.Context, ethClient *ethereum.Client, api *client.ImmutableXAPI, l1signer signers.L1Signer) (*eth.Transaction, error) {
 	if d.Type != types.ERC721Type {
 		return nil, errors.New("invalid token type")
 	}

--- a/src/workflows/deposits/depositEth.go
+++ b/src/workflows/deposits/depositEth.go
@@ -18,8 +18,8 @@ import (
 	helpers "immutable.com/imx-core-sdk-golang/workflows/utils"
 )
 
-// Execute performs the deposit workflow on the ETHDeposit.
-func (d *ETHDeposit) Execute(ctx context.Context, ethClient *ethereum.Client, api *client.ImmutableXAPI, l1signer signers.L1Signer) (*eth.Transaction, error) {
+// Deposit performs the deposit workflow on the ETHDeposit.
+func (d *ETHDeposit) Deposit(ctx context.Context, ethClient *ethereum.Client, api *client.ImmutableXAPI, l1signer signers.L1Signer) (*eth.Transaction, error) {
 	if d.Type != types.ETHType {
 		return nil, errors.New("invalid token type")
 	}

--- a/src/workflows/deposits/types.go
+++ b/src/workflows/deposits/types.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TokenDeposit interface {
-	Execute(ctx context.Context, ethClient *ethereum.Client, apis *client.ImmutableXAPI, l1signer signers.L1Signer) (*eth.Transaction, error)
+	Deposit(ctx context.Context, ethClient *ethereum.Client, apis *client.ImmutableXAPI, l1signer signers.L1Signer) (*eth.Transaction, error)
 }
 
 type ETHDeposit struct {


### PR DESCRIPTION
# Summary
Refactor deposit workflow method name


# Why the changes
Deposit is a better name for the method than Execute


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
