### PR TITLE
refactor(examples): replace log.Fatal with log.Panic

### DIFF
--- a/examples/workflows/burn/burn.go
+++ b/examples/workflows/burn/burn.go
@@ -26,7 +26,7 @@ func Demo_BurnWorkflow(ctx context.Context, api *client.ImmutableXAPI, l1signer 
 
 	burnResponse, err := burnWorkflow.Burn(ctx, api, l1signer, l2signer, tradeRequest)
 	if err != nil {
-		log.Fatalf("error calling burn workflow: %v", err)
+		log.Panicf("error calling burn workflow: %v", err)
 	}
 	val, _ := json.MarshalIndent(burnResponse, "", "  ")
 	log.Printf("Burn response:\n%s\n", val)
@@ -34,7 +34,7 @@ func Demo_BurnWorkflow(ctx context.Context, api *client.ImmutableXAPI, l1signer 
 	transferID := strconv.FormatInt(*burnResponse.TransferID, 10) // GetBurn method requires transferID as a string
 	transfer, err := burnWorkflow.GetBurn(ctx, api, transferID)
 	if err != nil {
-		log.Fatalf("error calling GetBurn workflow: %v", err)
+		log.Panicf("error calling GetBurn workflow: %v", err)
 	}
 	val, _ = json.MarshalIndent(transfer, "", "  ")
 	log.Printf("GetBurn response:\n%s\n", val)

--- a/examples/workflows/deposits/deposit.go
+++ b/examples/workflows/deposits/deposit.go
@@ -33,7 +33,7 @@ func Demo_DepositWorkflow(ctx context.Context, ethClient *ethereum.Client, apis 
 	*/
 
 	if err != nil {
-		log.Fatalf("error calling deposit workflow: %v", err)
+		log.Panicf("error calling deposit workflow: %v", err)
 	}
 
 	log.Println("transaction hash:", transaction.Hash())

--- a/examples/workflows/minting/minting.go
+++ b/examples/workflows/minting/minting.go
@@ -51,12 +51,12 @@ func Demo_MintingTokens(ctx context.Context, api *client.ImmutableXAPI, l1signer
 
 	mintTokensResponse, err := minting.MintTokensWorkflow(ctx, api, l1signer, request)
 	if err != nil {
-		log.Fatalf("error in minting.MintTokensWorkflow: %v", err)
+		log.Panicf("error in minting.MintTokensWorkflow: %v", err)
 	}
 
 	mintTokensResponseStr, err := utils.PrettyStruct(mintTokensResponse)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	log.Printf("Mint Tokens response:\n%v\n", mintTokensResponseStr)
 }

--- a/examples/workflows/onboarding/user_registration.go
+++ b/examples/workflows/onboarding/user_registration.go
@@ -17,23 +17,23 @@ func Demo_UserRegistrationWorkflow(ctx context.Context, apiClient *client.Immuta
 
 	l2signer, err := stark.GenerateStarkSigner(l1signer)
 	if err != nil {
-		log.Fatalf("error in creating StarkSigner: %v\n", err)
+		log.Panicf("error in creating StarkSigner: %v\n", err)
 	}
 
 	response, err := registration.RegisterOffchain(ctx, apiClient, l1signer, l2signer, "")
 	if err != nil {
-		log.Fatalf("error in creating StarkSigner: %v\n", err)
+		log.Panicf("error in creating StarkSigner: %v\n", err)
 	}
 
 	val, err := json.MarshalIndent(response, "", "    ")
 	if err != nil {
-		log.Fatalf("error in json marshaling: %v\n", err)
+		log.Panicf("error in json marshaling: %v\n", err)
 	}
 	log.Println("registration success, response: ", string(val))
 
 	accounts, err := registration.IsRegisteredOffChain(ctx, apiClient, l1signer.GetAddress())
 	if err != nil {
-		log.Fatalf("error in IsRegisteredOffChain function: %v\n", err)
+		log.Panicf("error in IsRegisteredOffChain function: %v\n", err)
 	}
 	log.Println("registered accounts: ", accounts)
 

--- a/examples/workflows/orders/orders.go
+++ b/examples/workflows/orders/orders.go
@@ -43,12 +43,12 @@ func Demo_OrdersWorkflow(ctx context.Context, apiClient *client.ImmutableXAPI, l
 	// Create order will list the given asset for sale.
 	createOrderResponse, err := ordersWorkflow.CreateOrder(ctx, apiClient, l1signer, l2signer, createOrderRequest)
 	if err != nil {
-		log.Fatalf("error calling CreateOrder workflow: %v", err)
+		log.Panicf("error calling CreateOrder workflow: %v", err)
 	}
 
 	createOrderResponseStr, err := utils.PrettyStruct(createOrderResponse)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	log.Printf("CreateOrder response:\n%v\n", createOrderResponseStr)
 
@@ -59,12 +59,12 @@ func Demo_OrdersWorkflow(ctx context.Context, apiClient *client.ImmutableXAPI, l
 	// Cancel Order removes the listed asset from sale. Let's remove the above listed asset from sale.
 	cancelOrderResponse, err := ordersWorkflow.CancelOrder(ctx, apiClient, l1signer, l2signer, cancelOrderRequest)
 	if err != nil {
-		log.Fatalf("error calling CreateOrder workflow: %v", err)
+		log.Panicf("error calling CreateOrder workflow: %v", err)
 	}
 
 	cancelOrderResponseStr, err := utils.PrettyStruct(cancelOrderResponse)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	log.Printf("CancelOrder response:\n%v\n", cancelOrderResponseStr)
 

--- a/examples/workflows/trades/trades.go
+++ b/examples/workflows/trades/trades.go
@@ -23,7 +23,7 @@ func Demo_TradesWorkflow(ctx context.Context, api *client.ImmutableXAPI, l1signe
 	tradeResponse, err := tradesWorkflow.CreateTrade(ctx, api, l1signer, l2signer, tradeRequest)
 
 	if err != nil {
-		log.Fatalf("error calling trades workflow: %v", err)
+		log.Panicf("error calling trades workflow: %v", err)
 	}
 
 	val, _ := json.MarshalIndent(tradeResponse, "", "  ")

--- a/examples/workflows/transfers/batchTransfers.go
+++ b/examples/workflows/transfers/batchTransfers.go
@@ -45,7 +45,7 @@ func Demo_BatchTransferWorkflow(ctx context.Context, api *client.ImmutableXAPI, 
 
 	response, err := transfersWorkflow.CreateBatchTransfer(ctx, api, l1signer, l2signer, batchTransferRequest)
 	if err != nil {
-		log.Fatalf("error calling batch transfer workflow: %v", err)
+		log.Panicf("error calling batch transfer workflow: %v", err)
 	}
 	val, _ := json.MarshalIndent(response, "", "  ")
 	log.Printf("response:\n%s\n", val)

--- a/examples/workflows/transfers/transfer.go
+++ b/examples/workflows/transfers/transfer.go
@@ -31,7 +31,7 @@ func Demo_TransferWorkflow(ctx context.Context, api *client.ImmutableXAPI, l1sig
 
 	response, err := transfersWorkflow.CreateTransfer(ctx, api, l1signer, l2signer, transferRequest)
 	if err != nil {
-		log.Fatalf("error calling transfer workflow: %v", err)
+		log.Panicf("error calling transfer workflow: %v", err)
 	}
 	val, _ := json.MarshalIndent(response, "", "  ")
 	log.Printf("response:\n%s\n", val)

--- a/examples/workflows/withdrawals/completeWithdrawal.go
+++ b/examples/workflows/withdrawals/completeWithdrawal.go
@@ -34,7 +34,7 @@ func Demo_CompleteWithdrawalWorkflow(ctx context.Context, ethClient *ethereum.Cl
 	*/
 
 	if err != nil {
-		log.Fatalf("error calling complete withdrawal workflow: %v", err)
+		log.Panicf("error calling complete withdrawal workflow: %v", err)
 	}
 	log.Println("transaction hash:", transaction.Hash())
 

--- a/examples/workflows/withdrawals/prepareWithdrawal.go
+++ b/examples/workflows/withdrawals/prepareWithdrawal.go
@@ -39,7 +39,7 @@ func Demo_PrepareWithdrawalWorkflow(ctx context.Context, api *client.ImmutableXA
 
 	response, err := withdrawalsWorkflow.PrepareWithdrawal(ctx, api, l1signer, l2signer, withdrawalRequest)
 	if err != nil {
-		log.Fatalf("error calling prepare withdrawal workflow: %v", err)
+		log.Panicf("error calling prepare withdrawal workflow: %v", err)
 	}
 	val, _ := json.MarshalIndent(response, "", "  ")
 	log.Printf("response:\n%s\n", val)


### PR DESCRIPTION
# Summary
replaced log.Fatal statements with log.Panic because Fatal doesn't allow deferred statements to run


# Why the changes
Linting highlighted that the log.Fatal calls are stopping deferred statements from being run.
Except linter will not detect log.Fatal statements in a method defined in another file.


# Things worth calling out
Linter does not notice the log.Fatal statements in methods defined outside of the file being linted.
