### PR TITLE
DX-998: Added scan for secrets on pull request workflow

### DIFF
--- a/.github/workflows/secrets.yaml
+++ b/.github/workflows/secrets.yaml
@@ -1,0 +1,17 @@
+name: Leaked Secrets Scan
+on: [pull_request]
+jobs:
+  TruffleHog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@v3.4.3
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+


### PR DESCRIPTION
# Summary
 
Added GitHub workflow to scan for secrets on pull request.


# Why the changes

Part of best practices in preparation for open sourcing repo.

# Things worth calling out

Refer, https://immutable.atlassian.net/wiki/spaces/SRE/pages/1897826483/Guide+Open+sourcing+a+code+repository+at+Immutable#Security-team-review