### PR TITLE
refactor: added comments to explain GasParams

### DIFF
--- a/src/utils/ethereum/client.go
+++ b/src/utils/ethereum/client.go
@@ -7,44 +7,50 @@ import (
 	"regexp"
 	"time"
 
-	"immutable.com/imx-core-sdk-golang/generated/contracts"
-	"immutable.com/imx-core-sdk-golang/signers"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"immutable.com/imx-core-sdk-golang/generated/contracts"
+	"immutable.com/imx-core-sdk-golang/signers"
 )
 
 const (
-	EthereumDefaultGasLimit uint64  = 300000       // Ethereum default gas limit in gas units
-	EthereumDefaultGasPrice uint64  = 160000000000 // Ethereum default gas price in wei
-	EthereumEGSAPIKey       string  = ""           // Ethereum eth gas station (EGS) API key
-	EthereumEGSSpeed        string  = "fast"       // Ethereum eth gas station (EGS) speed
-	EthereumGasMultiplier   float64 = 1.5          // Ethereum default gas multiplier
-	EthereumMaxGasPrice     uint64  = 300000000000 // Ethereum max gas price in wei
+	DefaultGasLimit      uint64  = 300000       // Ethereum default gas limit in gas units
+	DefaultGasPrice      uint64  = 160000000000 // Ethereum default gas price in wei
+	DefaultGasMultiplier float64 = 1.5          // Ethereum default gas multiplier
+	DefaultMaxGasPrice   uint64  = 300000000000 // Ethereum max gas price in wei
 )
 
 var DefaultGasParams = NewDefaultGasParams()
 
 func NewDefaultGasParams() GasParams {
 	return GasParams{
-		GasLimit:      EthereumDefaultGasLimit,
-		GasPrice:      big.NewInt(int64(EthereumDefaultGasPrice)),
-		GasMultiplier: EthereumGasMultiplier,
-		MaxGasPrice:   big.NewInt(int64(EthereumMaxGasPrice)),
-		EGSAPIKey:     EthereumEGSAPIKey,
-		EGSSpeed:      EthereumEGSSpeed,
+		GasLimit:      DefaultGasLimit,
+		GasPrice:      big.NewInt(int64(DefaultGasPrice)),
+		GasMultiplier: DefaultGasMultiplier,
+		MaxGasPrice:   big.NewInt(int64(DefaultMaxGasPrice)),
 	}
 }
 
+// GasParams are used to set the gas limit and gas price.
+// When EGSAPIKey is provided, Client.BuildTransactOpts will attempt to set the gas price returned from eth gas station.
+// If the api call to eth gas station fails, the gas price will be set at the (Network suggested price * GasMultiplier)
+// unless MaxGasPrice is lower, then gas price will be set at MaxGasPrice.
+// When EGSAPIKey is an empty string or if the api call to eth gas station fails, the gas price will be set at
+// the (Network suggested price * GasMultiplier) unless MaxGasPrice is lower, then gas price will be set at MaxGasPrice.
 type GasParams struct {
-	GasLimit      uint64
-	GasPrice      *big.Int
+	GasLimit uint64
+	GasPrice *big.Int
+	// GasMultiplier is used to adjust the GasPrice returned by the method SuggestGasPrice (eth_gasPrice)
+	// to control the speed of the ethereum transaction. E.g. a multiplier of 1.5 would set the gas price
+	// at 1.5 times the suggested gas price and should process faster than simply using the suggested gas price.
 	GasMultiplier float64
 	MaxGasPrice   *big.Int
-	EGSAPIKey     string
-	EGSSpeed      string
+	// Eth gas station (EGS) API key https://ethgasstation.info
+	EGSAPIKey string
+	// Eth gas station (EGS) speed https://ethgasstation.info
+	EGSSpeed string
 }
 
 type EtherClient interface {


### PR DESCRIPTION


# Summary
- added comments to explain GasParams
- linting fix: renamed constants to not start with package name.


# Why the changes
Refactored for clarity


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
