### PR TITLE
chore: add prod server to api configuration

### DIFF
--- a/generated/api/configuration.go
+++ b/generated/api/configuration.go
@@ -109,6 +109,10 @@ func NewConfiguration() *Configuration {
 				URL: "https://api.ropsten.x.immutable.com",
 				Description: "No description provided",
 			},
+			{
+				URL: "https://api.x.immutable.com",
+				Description: "No description provided",
+			},
 		},
 		OperationServers: map[string]ServerConfigurations{
 		},


### PR DESCRIPTION
# Summary
Since OAS3 containing multiple servers is not yet available we should just add this in so users can still find mainnet api server at config.Mainnet when using the api with `ctx := context.WithValue(context.Background(), api.ContextServerIndex, config.Mainnet)
`


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
