### PR TITLE
DX-1447: Fixed register and deposit workflow when user is not registe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - In examples moved stark signer creation to separate function as not every workflow will need it. Also done to address [ISSUE-94](https://github.com/immutable/imx-core-sdk-golang/issues/94)
 
+### Fixed
+
+- Deposit workflow for register and deposit NFT
+
 ## [v0.2.2] - 2022-11-11
 
 ### Fixed


### PR DESCRIPTION
# Summary
Fixed register and deposit workflow when user is not registered for ERC721 tokens.

# Why the changes
Proxy registration contract method `RegisterAndDepositNft` currently fails ownership check for `ERC721` transfer method. This workaround performs the register and deposit method calls separately.

See [DX-1447](https://immutable.atlassian.net/browse/DX-1447)


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [ N/A] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [N/A ] *Add documentation update 1*
    - [ N/A] *Add documentation update 2*
