### PR TITLE
[DX-1476] Add legacy stark keygen instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,56 @@ if err != nil {
 }
 ```
 
+## Generating Stark (Layer 2) keys
+
+Stark keys are required to transact on ImmutableX's StarkEx Layer 2. They are the equivalent of Ethereum keys on L1 and allow users to sign transactions like trade, transfer, etc.
+
+### Key registration
+
+On ImmutableX, the goal of generating a Stark key is to [register](https://docs.x.immutable.com/docs/how-to-register-users/) a mapping between the Stark public key and the user's Ethereum public key so that transactions requiring both L1 and L2 signers can be executed by users.
+
+### How to generate Stark keys on ImmutableX
+
+ImmutableX provides two Stark key generation methods:
+| Type of Stark key generated: | User connection methods: | When to use this method: | ImmutableX tools: |
+| --- | --- | --- | --- |
+| [Deterministic](#generating-or-retrieving-a-deterministic-key) - generated using the user's Ethereum key as a seed (which means that the same Ethereum key will always generate the same Stark key) | Users connect with their L1 wallet (ie. Metamask), as the L2 key can simply be obtained from the L1 key. | ***User experience*** - users don't have to store or remember Stark keys.<br/><br/> ***Interoperability*** - when generating Stark keys for a user, think about how else they will use these keys. If they will be connecting to other applications and those applications connect to users' Stark keys (L2 wallets) via an L1 wallet, then it is best that their Stark keys are generated using this method.  | [Link SDK](https://docs.x.immutable.com/docs/link-setup)<br/><br/>Core SDK's [`GenerateLegacyKey()`](https://github.com/immutable/imx-core-sdk-golang/blob/main/imx/signers/stark/factory.go#L57) method |
+| [Random and non-reproducible](#generating-a-random-non-deterministic-key) - not generated from a user's Ethereum key | Once this Stark key is [registered](#) on ImmutableX (mapped to an Ethereum key), the Stark key owner needs to know and input this.<br/><br/>**🚨 NOTE:** If this key isn't persisted and stored by the user, it cannot be recovered and a new key cannot be re-registered. | ***Security*** - a Stark key generated using this method is completely independent of an Ethereum key, so the compromise of an Ethereum key does not compromise a user's corresponding Stark key.<br/><br/>***Isolated use-case*** - this method is ideal for keys that are only used for one particular function, ie. in the backend of an application that allows tokens to be minted from a collection registered with this key. | <br/><br/>Core SDK's [`GenerateKey()`](https://github.com/immutable/imx-core-sdk-golang/blob/main/imx/signers/stark/factory.go#L33) method |
+
+### Generating or retrieving a deterministic key
+
+If your user has a Stark key that was generated using the deterministic method, the Core SDK provides a way for you to retrieve this key using the [`GenerateLegacyKey()`](https://github.com/immutable/imx-core-sdk-golang/blob/main/imx/signers/stark/factory.go#L57) method:
+```ts
+import { AlchemyProvider } from '@ethersproject/providers';
+import { Wallet } from '@ethersproject/wallet';
+import { generateLegacyStarkPrivateKey } from '@imtbl/core-sdk';
+
+// Create Ethereum signer
+const ethNetwork = 'goerli'; // Or 'mainnet'
+const provider = new AlchemyProvider(ethNetwork, YOUR_ALCHEMY_API_KEY);
+const ethSigner = new Wallet(YOUR_PRIVATE_ETH_KEY).connect(provider);
+
+// Get the legacy Stark private key
+const starkPrivateKey = generateLegacyStarkPrivateKey(ethSigner);
+```
+
+### Generating a random, non-deterministic key
+
+The Core SDK also provides a way to generate a random, non-reproducible key using the [`GenerateKey()`](https://github.com/immutable/imx-core-sdk-golang/blob/main/imx/signers/stark/factory.go#L33) method:
+
+#### 🚨🚨🚨 Warning 🚨🚨🚨
+> If you generate your own Stark private key, you will have to persist it. The key is [randomly generated](https://github.com/immutable/imx-core-sdk-golang/blob/main/imx/signers/stark/factory.go#L33) so **_cannot_** be deterministically re-generated.
+
+```go
+starkPrivateKey, err = stark.GenerateKey(l1signer)
+if err != nil {
+    log.Panicf("error in Generating Stark Private Key: %v\n", err)
+}
+```
+
 ## Operations requiring user signatures
+
+As Immutable X enables applications to execute signed transactions on both Ethereum (layer 1) and StarkEx (layer 2), signers are required for both these layers. In order to generate an Ethereum or Stark signer, a user's Ethereum or Stark private key is required.
 
 There are two types of operations requiring user signatures:
 
@@ -114,11 +163,11 @@ There are two types of operations requiring user signatures:
 
 In order to get user signatures, applications need to [generate "signers"](#how-do-applications-generate-and-use-signers).
 
-### What are transactions that update blockchain state?
+#### What are transactions that update blockchain state?
 
 A common transaction type is the transfer of asset ownership from one user to another (ie. asset sale). These operations require users to sign (approve) them to prove that they are valid.
 
-### What are operations that require authorization?
+#### What are operations that require authorization?
 
 These operations add to or update data in Immutable's databases and typically require the authorization of an object's owner (ie. a user creating a project on Immutable X).
 
@@ -135,47 +184,7 @@ The first option, where an application obtains a user's private key directly, is
 
 The second option provides an application with an interface to the user's account by prompting the user to connect with their wallet application (ie. mobile or browser wallet). Once connected the app can begin asking the user to sign transactions and messages without having to reveal their private key.
 
-### Pre-requisite: User must have Ethereum (L1) and Stark (L2) keys
-
-As Immutable X enables applications to execute signed transactions on both Ethereum (layer 1) and StarkEx (layer 2), signers are required for both these layers. In order to generate an Ethereum or Stark signer, a user's Ethereum or Stark private key is required.
-
-The Core SDK can be used to generate a Stark key for a user. Previously, this key was deterministically generated so that the same key could always be obtained using the user's Ethereum key. This meant that if someone had access to a user's L1 (Ethereum) private keys, they could also obtain the user's L2 (Stark) private keys. This has been updated so that Stark keys are now randomly generated and non-reproducible.
-
-If your user has a Stark key that was generated using the previous, deterministic method, you can still retrieve their Stark private key by using the [GenerateLegacyKey()](https://github.com/immutable/imx-core-sdk-golang/blob/main/imx/signers/stark/factory.go#L57) method:
-```go
-apiConfiguration := api.NewConfiguration()
-cfg := imx.Config{
-    APIConfig:     apiConfiguration,
-    AlchemyAPIKey: YOUR_ALCHEMY_API_KEY,
-    Environment:   imx.Sandbox,
-}
-
-// Create Ethereum signer
-l1signer, err := ethereum.NewSigner(YOUR_PRIVATE_ETH_KEY, cfg.ChainID)
-if err != nil {
-    log.Panicf("error in creating L1Signer: %v\n", err)
-}
-
-// Generate Stark legacy key
-starkPrivateKey, err = stark.GenerateLegacyKey(l1signer)
-if err != nil {
-    log.Panicf("error in Generating Stark Legacy Private Key: %v\n", err)
-}
-```
-
-If they do not yet have a Stark key, you can use the Core SDK to generate one for them using [GenerateKey()](https://github.com/immutable/imx-core-sdk-golang/blob/main/imx/signers/stark/factory.go#L30-L33):
-
-#### 🚨🚨🚨 Warning 🚨🚨🚨
-> If you generate your own Stark private key, you will have to persist it. The key is [randomly generated](https://github.com/immutable/imx-core-sdk-golang/blob/main/imx/signers/stark/factory.go#L33) so **_cannot_** be deterministically re-generated.
-
-```go
-starkPrivateKey, err = stark.GenerateKey(l1signer)
-if err != nil {
-    log.Panicf("error in Generating Stark Private Key: %v\n", err)
-}
-```
-
-### 1. Generate your own signers
+### 1. Generate L1 and L2 signers
 
 The Core SDK provides functionality for applications to generate Stark (L2) [signers](https://github.com/immutable/imx-core-sdk-golang/blob/69af5db9a0be05afd9c91c6b371547cfe3bea719/imx/signers/stark/signer.go#L16).
 
@@ -193,20 +202,9 @@ if err != nil {
     log.Panicf("error in creating L1Signer: %v\n", err)
 }
 
-// Generate Stark private key
-starkPrivateKey, err = stark.GenerateKey()
-if err != nil {
-    log.Panicf("error in Generating Stark Private Key: %v\n", err)
-}
-// Or retrieve previously generated key
-// starkPrivateKey, err = stark.GenerateLegacyKey()
-// if err != nil {
-//     log.Panicf("error in Generating Stark Private Key: %v\n", err)
-// }
-
 // Endpoints like Withdrawal, Orders, Trades, Transfers require an L2 (stark) signer
 // Create Stark signer
-l2signer, err := stark.NewSigner(starkPrivateKey)
+l2signer, err := stark.NewSigner(YOUR_PRIVATE_STARK_KEY)
 if err != nil {
     log.Panicf("error in creating StarkSigner: %v\n", err)
 }


### PR DESCRIPTION
# Summary
This PR updates the README to:
* Clarify Stark keygen changes
* Provide instructions for using the `GenerateLegacyKey()` method to retrieve the previously deterministically generated Stark key

# Why the changes
* To clear up confusion regarding how previous and current ways of generating the Stark key
* To provide users with clarity on how they can retrieve the old legacy generated key

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [x] `N/A`
