### PR TITLE
DX-1455: Removing v1.0 warning as we are into beta.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@
   </p>
 </div>
 
----
-**The Golang SDK interface is under active development and hasn't hit v1.0 yet.**
-
-Its public interface shouldn't be considered final, and we may need to release breaking changes as we push towards v1.0.
-
----
-
 # Immutable Core SDK Golang
 
 The Immutable Core SDK Golang provides convenient access to the Immutable X API and Ethereum smart contracts for applications written on the Immutable X platform.


### PR DESCRIPTION
# Summary
Removed warning as are going v1.0 beta

