### PR TITLE
fix: broken link in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ suggestion: Description # if you want to suggest a better way to implement a fea
 
 ## Send a pull request with changes
 
-For those unfamiliar with git, please follow the instructions [here](http://localhost:3000/docs/contributing#send-a-pull-request-pr-with-changes) on how to create a new pull request for this repository (replace `imx-docs` with `imx-core-sdk-golang`).
+For those unfamiliar with git, please follow the instructions [here](https://docs.x.immutable.com/docs/contributing/#send-a-pull-request-pr-with-changes) on how to create a new pull request for this repository (replace `imx-docs` with `imx-core-sdk-golang`).
 
 To ensure high quality contributions, please follow the guidelines below:
 * **Size:** Please keep pull requests small where possible (aim for 200-400 lines of code). Immutable prefers small pull requests to effectively review them.


### PR DESCRIPTION
# Summary
Current contributing docs are pointing to a localhost link. Changed to point to imx docs page instead 


# Why the changes


# Things worth calling out

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
