### PR TITLE
[DX-1698] Add section linking to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ See the [Developer Home](https://docs.x.immutable.com/) for general information 
 
 The following code snippets talk about how to get setup and use the various sections of the Golang SDK for most common use cases. Any questions that are not covered here please reach out to team. See [Getting Help](#getting-help)
 
+### Examples
+* **Sample code** - see the [examples](./imx/examples/) folder for sample code for key SDK functionality.
 
 ## Installation
 


### PR DESCRIPTION
# Summary
This adds a section to the README referencing where to find example code in this repo

Jira: https://immutable.atlassian.net/browse/DX-1698

# Why the changes
To make it easier for developers using this SDK to find examples

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [x] N/A