### PR TITLE
Fix typos in notes.md and Exchange.md documentation

### DIFF
--- a/git-hooks/notes.md
+++ b/git-hooks/notes.md
@@ -5,6 +5,6 @@
 golangci-lint is required to be installed for pre-commit hook to work. For instructions regarding installing golangci-lint, see https://golangci-lint.run/usage/install/#local-installation
 
 ## Installing Pre Commit Hook
-After cloning a git repo to you machine git hooks aren’t installed automatically. You’ll need to store them at your repository and reinstall each time you change their code or clone the repository to a new place.
+After cloning a git repo to your machine git hooks aren’t installed automatically. You’ll need to store them at your repository and reinstall each time you change their code or clone the repository to a new place.
 
 cp pre-commit ../.git/hooks/pre-commit

--- a/imx/api/docs/Exchange.md
+++ b/imx/api/docs/Exchange.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **Provider** | Pointer to **string** | Provider name | [optional] 
 **Status** | Pointer to **string** | Transaction status | [optional] 
 **Type** | Pointer to **string** | Transaction type | [optional] 
-**UpdatedAt** | Pointer to **string** | Time this transaction was updates | [optional] 
+**UpdatedAt** | Pointer to **string** | Time this transaction was updated | [optional] 
 **WalletAddress** | Pointer to **string** | Ethereum address of the user who created transaction | [optional] 
 
 ## Methods


### PR DESCRIPTION
# Summary
This PR addresses minor text corrections and typos in the documentation files `notes.md` and `Exchange.md`.

# Why the changes
The changes were made to fix grammatical errors and ensure clarity in the documentation:
1. Changed "you machine" to "your machine" in `notes.md`.
2. Corrected "was updates" to "was updated" in `Exchange.md`.

# Things worth calling out
- Fixed typographical issues that could confuse readers or lead to misinterpretation.
- No functional or structural changes were introduced, only documentation improvements.
